### PR TITLE
Some minor updates/fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mycroft-skill-jupiter-broadcasting
 My 2nd attempt at creating a mycroft skill
 
-This is a 3rd party skill that can either reside in `~/.mycroft/third_party_skills/` or `/opt/mycroft/third_party` .
+This is a 3rd party skill that can either reside in `~/.mycroft/skills/` or `/opt/mycroft/skills` .
 
 # Intents
 | Intent         | Example Keyphrase                                         | Function                                                    | Output                                                                                                            |
@@ -38,12 +38,13 @@ This is a 3rd party skill that can either reside in `~/.mycroft/third_party_skil
 | The Linux Action Show! |
 | Torked |
 | Unfilter |
+| User Error |
 | Women's Tech Radio |
 
 ## Install
 ```
-mkdir -p ~/.mycroft/third_party_skills/
-cd ~/.mycroft/third_party_skills/
+mkdir -p ~/.mycroft/skills/
+cd ~/.mycroft/skills/
 git clone https://github.com/the7erm/mycroft-skill-jupiter-broadcasting.git jupiter_broadcasting
 source ~/.virtualenvs/mycroft/bin/activate
 # if that doesn't work try `source <path to virtualenv/bin/activate>`

--- a/__init__.py
+++ b/__init__.py
@@ -299,6 +299,18 @@ SHOWS = {
         },
         "title": "Unfilter"
     },
+    "User Error": {
+        "href": "http://www.jupiterbroadcasting.com/show/error/",
+        "rss": {
+            "HD Video RSS": "https://feedpress.me"
+                             "/uevideo",
+            "MP3 Audio RSS": "https://feedpress.me"
+                             "/usererror",
+            "unfilter on iTunes": "https://itunes.apple.com/us/podcast"
+                                   "/user-error-podcast/id1145648639"
+        },
+        "title": "User Error"
+    },
     "Women's Tech Radio": {
         "href": "http://www.jupiterbroadcasting.com/show/wtr/"
     }
@@ -332,19 +344,19 @@ class JbSkill(MycroftSkill):
 
         listen_intent = IntentBuilder(
             "JbListenIntent").require("JbPlayKeyword").require(
-                "LatestKeyword").require("Show").build()
+                "LatestKeyword").require("Show").optionally("EpisodeKeyword").build()
 
         self.register_intent(listen_intent, self.handle_jb_listen_intent)
 
         latest_intent = IntentBuilder(
             "JbLatestIntent").require("LatestKeyword").require(
-                "Show").build()
+                "Show").optionally("EpisodeKeyword").build()
 
         self.register_intent(latest_intent, self.handle_jb_latest_intent)
 
         open_intent = IntentBuilder(
             "JbOpenIntent").require("OpenKeyword").require(
-                "Show").build()
+                "Show").optionally("EpisodeKeyword").build()
 
         self.register_intent(open_intent, self.handle_jb_open_intent)
 
@@ -380,6 +392,7 @@ class JbSkill(MycroftSkill):
             self.add_token(title, entry)
 
     def add_token(self, token, entry):
+        LOGGER.debug("show token added:%s" % token)
         self.register_vocabulary(token, "Show")
         if token in self.showmap:
             self.showmap[token] += entry
@@ -448,9 +461,9 @@ class JbSkill(MycroftSkill):
         return False
 
     def iterate_shows_to_latest(self, message, media=False):
-        show_name = message.metadata.get('Show')
+        show_name = message.data.get('Show')
         entries = self.showmap.get(show_name)
-        LOGGER.debug("message:%s" % message)
+        LOGGER.debug("show name:%s" %show_name )
         LOGGER.debug("latest entries:%s" % entries)
 
         if entries and len(entries) > 0:
@@ -484,9 +497,9 @@ class JbSkill(MycroftSkill):
         self.iterate_shows_to_latest(message, True)
 
     def handle_jb_open_intent(self, message):
-        show_name = message.metadata.get('Show')
+        show_name = message.data.get('Show')
         entries = self.showmap.get(show_name)
-        LOGGER.debug("message:%s" % message)
+        LOGGER.debug("show name:%s" %show_name )
 
         if entries and len(entries) > 0:
             entry = entries[0]

--- a/regex/en-us/latest.rx
+++ b/regex/en-us/latest.rx
@@ -1,4 +1,0 @@
-(?P<Show>.*) episode
-(?P<Show>.*) site
-(?P<Show>.*) page
-(?P<Show>.*)

--- a/vocab/en-us/EpisodeKeyword.voc
+++ b/vocab/en-us/EpisodeKeyword.voc
@@ -1,0 +1,3 @@
+episode
+site
+page


### PR DESCRIPTION
Hello the7erm, I hope you do not mind my submitting a pull request. 

The code as it was, would not allow the skill to run under mycroft-core 0.8.5-1. 
Below are the notes from the commit to get it working.

Added feeds for User Error Show and added to shows list in README.md

Regular expression mathing didn't always work as intended.
Since the show names are known, the regular expressions file
latest.rx was removed. In order to still allow 'episode', 'site'
and 'page' to be matched, an optionally() statement was used to match
the newly added EpisodeKeywords.voc.

As of mycroft-core commit ccceb62b7a35a1e021a198569e2472933a6dca0e (https://github.com/MycroftAI/mycroft-core/commit/ccceb62b7a35a1e021a198
569e2472933a6dca0e) message.metadata has been renamed to message.data.
All references to message.metadata have been changed to message.data.
Also changed LOGGER.debug statments to print the showname matched by the
intent parser instead of the message object.

As of mycroft-core commit 416191e5983db7cf59025d7bcbb770e25eefe98f (https://github.com/MycroftAI/mycroft-core/commit/416191e5983db7cf59025d7bcbb770e25eefe98f) the default directories for third party skills were changed to ~/.mycroft/skills and /opt/mycroft/skills, updated README.md to reflect the change.